### PR TITLE
issue63: Player Flag Status Feature Added Smart Contract

### DIFF
--- a/src/libraries/LibQuadraticVoting.sol
+++ b/src/libraries/LibQuadraticVoting.sol
@@ -73,18 +73,21 @@ library LibQuadraticVoting {
             //For each proposal
             scores[proposalIdx] = 0;
             for (uint256 vi = 0; vi < VotersVotes.length; vi++) {
+                ///@dev In LibQuadraticVoting function  computeScoresByVPIndex should take in list of whether participant proposed or not (infer from is active or not). If is true, the Gives benefits to everyone but himself action must be bypassed.
+
                 // For each potential voter
                 uint256[] memory voterVotes = VotersVotes[vi];
+                //If voter voted
+                scores[proposalIdx] += voterVotes[proposalIdx];
+                creditsUsed[vi] += voterVotes[proposalIdx] ** 2;
+
                 if (!voterVoted[vi]) {
                     // Check if voter wasn't voting
                     scores[proposalIdx] += notVotedGivesEveyone; // Gives benefits to everyone but himself
                     creditsUsed[vi] = q.voteCredits;
-                } else {
-                    //If voter voted
-                    scores[proposalIdx] += voterVotes[proposalIdx];
-                    creditsUsed[vi] += voterVotes[proposalIdx] ** 2;
-                    if (creditsUsed[vi] > q.voteCredits) require(false, "quadraticVotingError"); // revert quadraticVotingError("Quadratic: vote credits overrun", q.voteCredits, creditsUsed[vi]);
                 }
+
+                if (creditsUsed[vi] > q.voteCredits) require(false, "quadraticVotingError"); // revert quadraticVotingError("Quadratic: vote credits overrun", q.voteCredits, creditsUsed[vi]);
             }
         }
         return scores;


### PR DESCRIPTION
[Issue63](https://github.com/peeramid-labs/contracts/issues/63) smart contract dev

Currently round ends on timeout or when all players made their turn.

It's quite common for newcomers to drop off the game, hence we would like to modify current logic so that

By default when game starts all players are flagged active
If player did not made any activity previous round, he is flagged as idle
Early turn ending is possible if all active members made their move.
If player made a move and playerMove is called, player must be set back to active
In LibQuadraticVoting function  computeScoresByVPIndex should take in list of whether participant proposed or not (infer from is active or not). If is true, the Gives benefits to everyone but himself action must be bypassed.
Flag can be added to LibTurnBasedGame.sol -> struct GameInstance.

The check for early ending can be added to LibTurnBasedGame -> struct canEndTurnEarly